### PR TITLE
Create Rgiht-shift-register.vhd

### DIFF
--- a/Rgiht-shift-register.vhd
+++ b/Rgiht-shift-register.vhd
@@ -1,0 +1,32 @@
+library IEEE;library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+entity RSHIFT is
+Port (IP,CLK,SL : in STD_LOGIC;
+D : in STD_LOGIC_VECTOR (3 downto 0);
+OP : out STD_LOGIC_VECTOR (3 downto 0));
+end RSHIFT;
+architecture Behavioral of RSHIFT is
+component DFF is
+Port ( RST,CLK,D : in STD_LOGIC;
+Q,Qbar : out STD_LOGIC);
+end component;
+component MUX2X1 is
+Port ( A0,A1,S : in STD_LOGIC;
+F : out STD_LOGIC);
+end component;
+signal Y3,Y2,Y1,Y0: STD_LOGIC;
+signal X3,X2,X1,X0: STD_LOGIC;
+begin
+MUX0: MUX2X1 port map (A0=>Y1,A1=>D(0),S=>SL,F=>X0);
+MUX1: MUX2X1 port map (A0=>Y2,A1=>D(1),S=>SL,F=>X1);
+MUX2: MUX2X1 port map (A0=>Y3,A1=>D(2),S=>SL,F=>X2);
+MUX3: MUX2X1 port map (A0=>IP,A1=>D(3),S=>SL,F=>X3);
+DFF0: DFF port map (RST=>'0',CLK=>CLK,D=>X0,Q=>Y0);
+DFF1: DFF port map (RST=>'0',CLK=>CLK,D=>X1,Q=>Y1);
+DFF2: DFF port map (RST=>'0',CLK=>CLK,D=>X2,Q=>Y2);
+DFF3: DFF port map (RST=>'0',CLK=>CLK,D=>X3,Q=>Y3);
+OP(0)<= Y0;
+OP(1)<= Y1;
+OP(2)<= Y2;
+OP(3)<= Y3;
+end Behavioral;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] 🌟 stared the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

An n-bit shift register can be formed by connecting n flip-flops where each flip flop stores a single bit of data.
The registers which will shift the bits to right are called “Shift right registers”. Here in this 4-bit right shift
register we are using four 2x1 MUX to create a control for loading the data as well as right shifting it using the
control signal.
a. Control = SET/ 1 : The initial Data is loaded into the DFFs.
b. Control = RESET/ 0 : Right Shifting of the data is performed with every clock pulse.


![image](https://user-images.githubusercontent.com/93468894/139577829-a97892fa-52a5-46a8-913c-3377cf63bd4d.png)


## Add Link of GitHub Profile


