### PR TITLE
Create Universal-shift-register.vhd

### DIFF
--- a/Universal-shift-register.vhd
+++ b/Universal-shift-register.vhd
@@ -1,0 +1,34 @@
+Code:
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+entity LSHIFT is
+Port (IP,CLK,SL : in STD_LOGIC;
+D : in STD_LOGIC_VECTOR (3 downto 0);
+OP : out STD_LOGIC_VECTOR (3 downto 0));
+end LSHIFT;
+architecture Behavioral of LSHIFT is
+component DFF is
+Port ( RST,CLK,D : in STD_LOGIC;
+Q,Qbar : out STD_LOGIC);
+end component;
+component MUX2X1 is
+Port ( A0,A1,S : in STD_LOGIC;
+F : out STD_LOGIC);
+end component;
+signal Y3,Y2,Y1,Y0: STD_LOGIC;
+signal X3,X2,X1,X0: STD_LOGIC;
+begin
+MUX0: MUX2X1 port map (A0=>IP,A1=>D(0),S=>SL,F=>X0);
+MUX1: MUX2X1 port map (A0=>Y0,A1=>D(1),S=>SL,F=>X1);
+MUX2: MUX2X1 port map (A0=>Y1,A1=>D(2),S=>SL,F=>X2);
+MUX3: MUX2X1 port map (A0=>Y2,A1=>D(3),S=>SL,F=>X3);
+DFF0: DFF port map (RST=>'0',CLK=>CLK,D=>X0,Q=>Y0);
+DFF1: DFF port map (RST=>'0',CLK=>CLK,D=>X1,Q=>Y1);
+DFF2: DFF port map (RST=>'0',CLK=>CLK,D=>X2,Q=>Y2);
+DFF3: DFF port map (RST=>'0',CLK=>CLK,D=>X3,Q=>Y3);
+OP(0)<= Y0;
+OP(1)<= Y1;
+OP(2)<= Y2;
+OP(3)<= Y3;
+end Behavioral;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] 🌟 stared the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description
Universal Shift Register:
A register that can store the data and shifts the data towards the right and left along with the parallel load
capability is known as a universal shift register. It can be used to perform input/output operations in both serial
and parallel modes. Unidirectional shift registers and bidirectional shift registers are combined together to get
the design of the universal shift register. It is also known as a parallel-in-parallel-out shift register or shift
register with the parallel load.
Universal shift registers are capable of performing 3 operations as listed below.
a. Parallel load operation – stores the data in parallel as well as the data in parallel
b. Shift left operation – stores the data and transfers the data shifting towards left in the serial path
c. Shift right operation – stores the data and transfers the data by shifting towards right in the serial path.
Hence, Universal shift registers can perform input/output operations with both serial and parallel loads.

![image](https://user-images.githubusercontent.com/93468894/139577972-511b466b-4e38-4644-8641-1d20ee0626e2.png)

![image](https://user-images.githubusercontent.com/93468894/139577975-a350f304-b89e-49a9-9202-1efbfaa6770a.png)



## Add Link of GitHub Profile


